### PR TITLE
Versioning fix (#8)

### DIFF
--- a/tap_ordway/__init__.py
+++ b/tap_ordway/__init__.py
@@ -207,7 +207,7 @@ def prepare_stream(
                 )
 
                 write_bookmark(
-                    state, substream_def.tap_stream_id, "is_first_run", False
+                    state, substream_def.tap_stream_id, "wrote_initial_activate_version", True
                 )
                 write_state(state)
 
@@ -231,7 +231,7 @@ def prepare_stream(
             stream_version,
         )
 
-        write_bookmark(state, stream_def.tap_stream_id, "is_first_run", False)
+        write_bookmark(state, stream_def.tap_stream_id, "wrote_initial_activate_version", True)
         write_state(state)
 
     return filter_datetime

--- a/tap_ordway/__init__.py
+++ b/tap_ordway/__init__.py
@@ -4,7 +4,7 @@ import json
 import os
 from _datetime import datetime
 from singer import get_logger
-from singer.bookmarks import get_bookmark, set_currently_syncing, write_bookmark
+from singer.bookmarks import set_currently_syncing, write_bookmark
 from singer.catalog import Catalog, CatalogEntry
 from singer.messages import write_schema, write_state
 from singer.schema import Schema
@@ -200,13 +200,15 @@ def prepare_stream(
 
             # All substreams are necessarily FULL_TABLE, so no need to
             # check if they're INCREMENTAL
-            if is_first_run(substream_def, state):
+            if is_first_run(substream_def.tap_stream_id, state):
                 write_activate_version(
                     substream_def.tap_stream_id,
                     substream_version,
                 )
 
-                write_bookmark(state, substream_def.tap_stream_id, "is_first_run", False)
+                write_bookmark(
+                    state, substream_def.tap_stream_id, "is_first_run", False
+                )
                 write_state(state)
 
     write_schema(
@@ -216,10 +218,14 @@ def prepare_stream(
     )
 
     filter_datetime = get_filter_datetime(stream_def, config["start_date"], state)
-    stream_version = None if stream_def.is_valid_incremental else get_full_table_version()
+    stream_version = (
+        None if stream_def.is_valid_incremental else get_full_table_version()
+    )
     stream_versions[stream_def.tap_stream_id] = stream_version
 
-    if not stream_def.is_valid_incremental and is_first_run(stream_def, state):
+    if not stream_def.is_valid_incremental and is_first_run(
+        stream_def.tap_stream_id, state
+    ):
         write_activate_version(
             stream_def.tap_stream_id,
             stream_version,
@@ -273,7 +279,7 @@ def sync(config: Dict[str, Any], state: Dict[str, Any], catalog: Catalog) -> Non
             if not substream_def.is_selected:
                 continue
 
-            # All substreams are necessarily FULL_TABLE and thus have a version, 
+            # All substreams are necessarily FULL_TABLE and thus have a version,
             # so write their ACTIVATE_VERSION messages without check.
             write_activate_version(
                 substream_def.tap_stream_id,

--- a/tap_ordway/utils.py
+++ b/tap_ordway/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from time import time
 from inflection import underscore
 from singer.bookmarks import get_bookmark
@@ -33,6 +33,10 @@ def get_full_table_version() -> int:
 
     return int(time() * 1000)
 
+def is_first_run(stream: "StreamABC", state: Dict[str, Any]) -> bool:
+    """Checks bookmarks to determine if its a stream's first run"""
+
+    return get_bookmark(state, stream.tap_stream_id, "is_first_run", default=True) is True
 
 def get_filter_datetime(
     stream: "StreamABC", start_date: str, state: Dict[str, Any]

--- a/tap_ordway/utils.py
+++ b/tap_ordway/utils.py
@@ -34,25 +34,6 @@ def get_full_table_version() -> int:
     return int(time() * 1000)
 
 
-def get_version(
-    stream: "StreamABC", start_date: str, filter_datetime: Optional["datetime"] = None
-) -> Optional[int]:
-    """ Generates a version for `stream` """
-
-    is_first_run = True
-
-    if filter_datetime is not None:
-        is_first_run = filter_datetime <= strptime_to_utc(start_date)
-
-    if stream.is_valid_incremental:
-        if is_first_run:
-            return 1
-
-        return None
-
-    return get_full_table_version()
-
-
 def get_filter_datetime(
     stream: "StreamABC", start_date: str, state: Dict[str, Any]
 ) -> "datetime":

--- a/tap_ordway/utils.py
+++ b/tap_ordway/utils.py
@@ -37,12 +37,12 @@ def get_full_table_version() -> int:
 def is_first_run(tap_stream_id: str, state: Dict[str, Any]) -> bool:
     """Checks bookmarks to determine if its a stream's first run"""
 
-    value = get_bookmark(state, tap_stream_id, "is_first_run", default=True) 
+    value = get_bookmark(state, tap_stream_id, "wrote_initial_activate_version", default=False) 
 
     if not isinstance(value, bool):
         return True
 
-    return value
+    return not value
 
 
 def get_filter_datetime(

--- a/tap_ordway/utils.py
+++ b/tap_ordway/utils.py
@@ -33,10 +33,17 @@ def get_full_table_version() -> int:
 
     return int(time() * 1000)
 
-def is_first_run(stream: "StreamABC", state: Dict[str, Any]) -> bool:
+
+def is_first_run(tap_stream_id: str, state: Dict[str, Any]) -> bool:
     """Checks bookmarks to determine if its a stream's first run"""
 
-    return get_bookmark(state, stream.tap_stream_id, "is_first_run", default=True) is True
+    value = get_bookmark(state, tap_stream_id, "is_first_run", default=True) 
+
+    if not isinstance(value, bool):
+        return True
+
+    return value
+
 
 def get_filter_datetime(
     stream: "StreamABC", start_date: str, state: Dict[str, Any]

--- a/tests/integration/test_contacts.py
+++ b/tests/integration/test_contacts.py
@@ -35,7 +35,7 @@ class ContactsTestCase(BaseOrdwayTestCase):
                 )
             ),
             18,
-            msg='"contacts" stream should emit 52 RECORDs',
+            msg='"contacts" stream should emit 18 RECORDs',
         )
         self.assertEqual(
             len(
@@ -45,7 +45,7 @@ class ContactsTestCase(BaseOrdwayTestCase):
                     )
                 )
             ),
-            1,
+            2,
         )
         self.assertEqual(
             len(
@@ -57,7 +57,7 @@ class ContactsTestCase(BaseOrdwayTestCase):
             ),
             1,
         )
-        self.assertMessageCountEqual(20, "contacts")
+        self.assertMessageCountEqual(21, "contacts")
 
     def test_records_included(self):
         self.assertMessagesIncludesAll(

--- a/tests/integration/test_customers.py
+++ b/tests/integration/test_customers.py
@@ -61,7 +61,7 @@ class CustomersTestCase(BaseOrdwayTestCase):
                 )
             ),
             19,
-            msg='"customers" stream should emit 52 RECORDs',
+            msg='"customers" stream should emit 19 RECORDs',
         )
         self.assertEqual(
             len(
@@ -71,7 +71,7 @@ class CustomersTestCase(BaseOrdwayTestCase):
                     )
                 )
             ),
-            1,
+            2,
         )
         self.assertEqual(
             len(
@@ -83,7 +83,7 @@ class CustomersTestCase(BaseOrdwayTestCase):
             ),
             1,
         )
-        self.assertMessageCountEqual(21, "customers")
+        self.assertMessageCountEqual(22, "customers")
 
     def test_records_included(self):
         self.assertMessagesIncludesAll(

--- a/tests/integration/test_invoices.py
+++ b/tests/integration/test_invoices.py
@@ -52,7 +52,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
     RESPONSE_MUTATORS = (_remove_custom_fields,)
 
     def test_stream_version(self):
-        self.assertStreamVersion("invoices", 1)
+        self.assertStreamVersion("invoices", None)
 
     def test_records_follow_schema(self):
         self.assertRecordMessagesFollowSchema()
@@ -68,7 +68,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                 )
             ),
             56,
-            msg='"invoices" stream should emit 52 RECORDs',
+            msg='"invoices" stream should emit 56 RECORDs',
         )
         self.assertEqual(
             len(
@@ -78,7 +78,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                     )
                 )
             ),
-            1,
+            0,
         )
         self.assertEqual(
             len(
@@ -90,7 +90,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
             ),
             1,
         )
-        self.assertMessageCountEqual(58, "invoices")
+        self.assertMessageCountEqual(57, "invoices")
 
     def test_records_included(self):
         self.assertMessagesIncludesAll(
@@ -178,7 +178,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                         "created_by": "heeyeg5i@example.com",
                         "updated_by": "s1rkw1w4@example.com",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "invoices",
@@ -263,7 +263,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                         "created_by": "73tr1lsh@example.com",
                         "updated_by": "022pl4kr@example.com",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "invoices",
@@ -348,7 +348,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                         "created_by": "73tr1lsh@example.com",
                         "updated_by": "022pl4kr@example.com",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "invoices",
@@ -433,7 +433,7 @@ class InvoicesTestCase(BaseOrdwayTestCase):
                         "created_by": "wx8626qy@example.com",
                         "updated_by": "lxkxssmk@example.com",
                     },
-                    version=1,
+                    version=None,
                 ),
             ],
             ignored_keys=["company_id"],

--- a/tests/integration/test_plans.py
+++ b/tests/integration/test_plans.py
@@ -52,7 +52,7 @@ class PlansTestCase(BaseOrdwayTestCase):
                     )
                 )
             ),
-            1,
+            2,
         )
         self.assertEqual(
             len(
@@ -64,7 +64,7 @@ class PlansTestCase(BaseOrdwayTestCase):
             ),
             1,
         )
-        self.assertMessageCountEqual(7, "plans")
+        self.assertMessageCountEqual(8, "plans")
 
     def test_all_records_included(self):
         self.assertMessagesIncludesAll(

--- a/tests/integration/test_refunds.py
+++ b/tests/integration/test_refunds.py
@@ -19,7 +19,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
     MASKED_RESPONSE_FORMATS = [StrFormat.EMAIL]
 
     def test_stream_version(self):
-        self.assertStreamVersion("refunds", 1)
+        self.assertStreamVersion("refunds", None)
 
     def test_message_count(self):
         self.assertStreamInOutput("refunds")
@@ -42,7 +42,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                     )
                 )
             ),
-            1,
+            0,
         )
         self.assertEqual(
             len(
@@ -54,7 +54,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
             ),
             1,
         )
-        self.assertMessageCountEqual(15, "refunds")
+        self.assertMessageCountEqual(14, "refunds")
 
     def test_records_included(self):
         self.assertMessagesIncludesAll(
@@ -77,7 +77,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                         "company_id": "test_company",
                         "refund_id": "REF-00120",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "refunds",
@@ -97,7 +97,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                         "company_id": "test_company",
                         "refund_id": "REF-00121",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "refunds",
@@ -117,7 +117,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                         "company_id": "test_company",
                         "refund_id": "REF-00122",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "refunds",
@@ -137,7 +137,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                         "company_id": "test_company",
                         "refund_id": "REF-00131",
                     },
-                    version=1,
+                    version=None,
                 ),
                 RecordMessage(
                     "refunds",
@@ -157,7 +157,7 @@ class RefundsTestCase(BaseOrdwayTestCase):
                         "company_id": "test_company",
                         "refund_id": "REF-00130",
                     },
-                    version=1,
+                    version=None,
                 ),
             ],
             ignored_keys=["company_id"],

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -9,7 +9,7 @@ from tap_ordway import filter_record, handle_record, prepare_stream
 class PrepareStreamTestCase(TestCase):
     @patch("tap_ordway.write_activate_version", autospec=True)
     def test_is_first_run_true_full_table(self, mock_write_activate_version):
-        """Ensure a FULL_TABLE run without `is_first_run` being set to True in
+        """Ensure a FULL_TABLE run without `wrote_initial_activate_version` being set to True in
         bookmarks results in an initial ACTIVATE_VERSION message being sent
         """
 
@@ -29,7 +29,7 @@ class PrepareStreamTestCase(TestCase):
     @patch("tap_ordway.get_full_table_version", autospec=True)
     @patch("tap_ordway.write_activate_version", autospec=True)
     def test_is_first_run_full_table_as_substream(self, mock_write_activate_version, mock_get_full_table_version):
-        """Ensure a FULL_TABLE run without `is_first_run` being set to True in
+        """Ensure a FULL_TABLE run without `wrote_initial_activate_version` being set to True in
         bookmarks results in an initial ACTIVATE_VERSION message being sent for SUBSTREAMS
         """
         mock_get_full_table_version.return_value = 123
@@ -53,7 +53,7 @@ class PrepareStreamTestCase(TestCase):
 
     @patch("tap_ordway.write_activate_version", autospec=True)
     def test_is_first_run_false_full_table(self, mock_write_activate_version):
-        """Ensure a FULL_TABLE run with `is_first_run` being set to False in
+        """Ensure a FULL_TABLE run with `wrote_initial_activate_version` being set to True in
         bookmarks DOES NOT result in an initial ACTIVATE_VERSION message being sent
         """
         prepare_stream(
@@ -64,14 +64,14 @@ class PrepareStreamTestCase(TestCase):
                 {"tap_stream_id": "webhooks", "selected": True, "replication_key": None, "replication_method": "FULL_TABLE"},
             ]),
             config={"start_date": "2021-01-01"},
-            state={"bookmarks": {"webhooks": {"is_first_run": False}}},
+            state={"bookmarks": {"webhooks": {"wrote_initial_activate_version": True}}},
         )
 
         mock_write_activate_version.assert_not_called()
 
     @patch("tap_ordway.write_activate_version", autospec=True)
     def test_is_first_run_true_incremental(self, mock_write_activate_version):
-        """Ensure an INCREMENTAL run with `is_first_run` being set to True in
+        """Ensure an INCREMENTAL run with `wrote_initial_activate_version` being set to True in
         bookmarks DOES NOT result in an initial ACTIVATE_VERSION message being sent
         (expected not to be sent in general for INCREMENTAL)
         """
@@ -83,7 +83,7 @@ class PrepareStreamTestCase(TestCase):
                 {"tap_stream_id": "invoices", "selected": True, "replication_key": "updated_date", "replication_method": "INCREMENTAL"},
             ]),
             config={"start_date": "2021-01-01"},
-            state={"bookmarks": {"invoices": {"is_first_run": True}}},
+            state={"bookmarks": {"invoices": {"wrote_initial_activate_version": True}}},
         )
 
         mock_write_activate_version.assert_not_called()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2,7 +2,91 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from datetime import datetime
 from pytz import UTC
-from tap_ordway import filter_record, handle_record
+from tests.utils import generate_catalog
+from tap_ordway import filter_record, handle_record, prepare_stream
+
+
+class PrepareStreamTestCase(TestCase):
+    @patch("tap_ordway.write_activate_version", autospec=True)
+    def test_is_first_run_true_full_table(self, mock_write_activate_version):
+        """Ensure a FULL_TABLE run without `is_first_run` being set to True in
+        bookmarks results in an initial ACTIVATE_VERSION message being sent
+        """
+
+        prepare_stream(
+            tap_stream_id="webhooks",
+            stream_defs={},
+            stream_versions={},
+            catalog=generate_catalog([
+                {"tap_stream_id": "webhooks", "selected": True, "replication_key": None, "replication_method": "FULL_TABLE"},
+            ]),
+            config={"start_date": "2021-01-01"},
+            state={"bookmarks": {"webhooks": {}}},
+        )
+
+        mock_write_activate_version.assert_called_once()
+
+    @patch("tap_ordway.get_full_table_version", autospec=True)
+    @patch("tap_ordway.write_activate_version", autospec=True)
+    def test_is_first_run_full_table_as_substream(self, mock_write_activate_version, mock_get_full_table_version):
+        """Ensure a FULL_TABLE run without `is_first_run` being set to True in
+        bookmarks results in an initial ACTIVATE_VERSION message being sent for SUBSTREAMS
+        """
+        mock_get_full_table_version.return_value = 123
+
+        prepare_stream(
+            tap_stream_id="plans",
+            stream_defs={},
+            stream_versions={},
+            catalog=generate_catalog([
+                {"tap_stream_id": "plans", "selected": True, "replication_key": None, "replication_method": "FULL_TABLE"},
+                {"tap_stream_id": "charges", "selected": True, "replication_key": None, "replication_method": "FULL_TABLE"},
+            ]),
+            config={"start_date": "2021-01-01"},
+            state={"bookmarks": {"charges": {}}},
+        )
+
+        mock_write_activate_version.assert_any_call(
+            "charges", 
+            123
+        )
+
+    @patch("tap_ordway.write_activate_version", autospec=True)
+    def test_is_first_run_false_full_table(self, mock_write_activate_version):
+        """Ensure a FULL_TABLE run with `is_first_run` being set to False in
+        bookmarks DOES NOT result in an initial ACTIVATE_VERSION message being sent
+        """
+        prepare_stream(
+            tap_stream_id="webhooks",
+            stream_defs={},
+            stream_versions={},
+            catalog=generate_catalog([
+                {"tap_stream_id": "webhooks", "selected": True, "replication_key": None, "replication_method": "FULL_TABLE"},
+            ]),
+            config={"start_date": "2021-01-01"},
+            state={"bookmarks": {"webhooks": {"is_first_run": False}}},
+        )
+
+        mock_write_activate_version.assert_not_called()
+
+    @patch("tap_ordway.write_activate_version", autospec=True)
+    def test_is_first_run_true_incremental(self, mock_write_activate_version):
+        """Ensure an INCREMENTAL run with `is_first_run` being set to True in
+        bookmarks DOES NOT result in an initial ACTIVATE_VERSION message being sent
+        (expected not to be sent in general for INCREMENTAL)
+        """
+        prepare_stream(
+            tap_stream_id="invoices",
+            stream_defs={},
+            stream_versions={},
+            catalog=generate_catalog([
+                {"tap_stream_id": "invoices", "selected": True, "replication_key": "updated_date", "replication_method": "INCREMENTAL"},
+            ]),
+            config={"start_date": "2021-01-01"},
+            state={"bookmarks": {"invoices": {"is_first_run": True}}},
+        )
+
+        mock_write_activate_version.assert_not_called()
 
 
 class FilterRecordTestCase(TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,6 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
-from datetime import datetime
-from pytz import UTC
-from tap_ordway.utils import denest, get_company_id, get_full_table_version, get_version
+from unittest.mock import patch
+from tap_ordway.utils import denest, get_company_id, get_full_table_version
 
 
 @patch.dict(
@@ -20,40 +18,6 @@ def test_get_full_table_version(mocked_time):
 
     assert get_full_table_version() == 1337000
     assert mocked_time.call_count == 1
-
-
-class GetVersionTestCase(TestCase):
-    @patch("tap_ordway.utils.get_full_table_version")
-    def test_full_table_stream(self, mocked_get_full_table_version):
-        """ Ensure get_full_table_version is invoked on FULL_TABLE streams """
-
-        mocked_stream = MagicMock()
-        mocked_stream.is_valid_incremental = False
-
-        get_version(mocked_stream, "2020-01-01", None)
-
-        self.assertEqual(mocked_get_full_table_version.call_count, 1)
-
-    def test_version_is_1_when_incremental_first_run(self):
-        mocked_stream = MagicMock()
-        mocked_stream.is_valid_incremental = True
-
-        version = get_version(
-            mocked_stream, "2020-01-01", datetime(2018, 12, 1, tzinfo=UTC)
-        )
-        self.assertEqual(version, 1)
-
-        version = get_version(mocked_stream, "2020-01-01", None)
-        self.assertEqual(version, 1)
-
-    def test_version_is_None_on_incremental_non_first_runs(self):
-        mocked_stream = MagicMock()
-        mocked_stream.is_valid_incremental = True
-
-        version = get_version(
-            mocked_stream, "2020-01-01", datetime(2020, 2, 1, tzinfo=UTC)
-        )
-        self.assertIsNone(version)
 
 
 class DenestTestCase(TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,25 +26,25 @@ def test_get_full_table_version(mocked_time):
 
 
 def test_is_first_run():
-    """Ensure returns true if `is_first_run` is either: a non-True value or not
+    """Ensure returns True if `wrote_initial_activate_version` is either: a non-True value or not
     found in bookmarks - else returns False
     """
 
     assert (
-        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": False}}})
+        is_first_run("payments", {"bookmarks": {"payments": {"wrote_initial_activate_version": True}}})
         is False
     )
     assert (
-        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": True}}})
+        is_first_run("payments", {"bookmarks": {"payments": {"wrote_initial_activate_version": False}}})
         is True
     )
     assert is_first_run("payments", {"bookmarks": {}}) is True
     assert (
-        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": 1}}})
+        is_first_run("payments", {"bookmarks": {"payments": {"wrote_initial_activate_version": 1}}})
         is True
     )
     assert (
-        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": "true"}}})
+        is_first_run("payments", {"bookmarks": {"payments": {"wrote_initial_activate_version": "true"}}})
         is True
     )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,11 @@
 from unittest import TestCase
 from unittest.mock import patch
-from tap_ordway.utils import denest, get_company_id, get_full_table_version
+from tap_ordway.utils import (
+    denest,
+    get_company_id,
+    get_full_table_version,
+    is_first_run,
+)
 
 
 @patch.dict(
@@ -18,6 +23,30 @@ def test_get_full_table_version(mocked_time):
 
     assert get_full_table_version() == 1337000
     assert mocked_time.call_count == 1
+
+
+def test_is_first_run():
+    """Ensure returns true if `is_first_run` is either: a non-True value or not
+    found in bookmarks - else returns False
+    """
+
+    assert (
+        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": False}}})
+        is False
+    )
+    assert (
+        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": True}}})
+        is True
+    )
+    assert is_first_run("payments", {"bookmarks": {}}) is True
+    assert (
+        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": 1}}})
+        is True
+    )
+    assert (
+        is_first_run("payments", {"bookmarks": {"payments": {"is_first_run": "true"}}})
+        is True
+    )
 
 
 class DenestTestCase(TestCase):


### PR DESCRIPTION
# Description of change
Addresses issue #8 

(Long day, 2 AM.  😴  Apologies if you have any trouble parsing this.)

- `INCREMENTAL` streams' `RECORD` messages no longer have `version` property
- `INCREMENTAL` streams no longer emit `ACTIVATE_VERSION` messages
- `FULL_TABLE` streams emit an `ACTIVATE_VERSION` message only once following `RECORD` messages **unless** it is the initial run (as determined by `wrote_initial_active_version` bookmark)
- Fixed erroneous assertion messages in tests (unrelated to referenced issue; no risks associated with this change)

# Manual QA steps
 - Run tap with incremental and full table streams selected.
 - Confirm no incremental stream has an `ACTIVATE_VERSION` message associated with it, and no `version` tagged to a `RECORD`.
 - Confirm all full table streams have two `ACTIVATE_VERSION` messages sandwiching their associated `RECORD` messages.
 - Confirm tap writes `wrote_initial_activate_version` bookmark for all selected full table streams, and that its value is `True`.
 - Re-run tap with state.
 - Confirm tap writes only one `ACTIVATE_VERSION` message for each full table stream, and that the `ACTIVATE_VERSION` message is following all of those stream's `RECORD` messages.
 
# Risks
 - Could, if not properly fixed, unexpectedly truncate a data store.
 
# Rollback steps
 - revert this branch
