### PR TITLE
Bump to v0.2.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+  * Fix JSON Schema validator in CircleCI [#7](https://github.com/singer-io/tap-ordway/pull/7)
+  * Remove versions from Incremental Streams [#9](https://github.com/singer-io/tap-ordway/pull/9)
+  * Change when Full Table Streams send an `ACTIVATE_VERSION` message [#9](https://github.com/singer-io/tap-ordway/pull/9)
+
 ## 0.1.2
   * Fixed the schema transform issues
 

--- a/tap_ordway/__version__.py
+++ b/tap_ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.2"  # pragma: no cover
+__version__ = "0.2.0"  # pragma: no cover


### PR DESCRIPTION
# Description of change
This is a version bump for #7 and #9 

## 0.2.0
  * Fix JSON Schema validator in CircleCI [#7](https://github.com/singer-io/tap-ordway/pull/7)
  * Remove versions from Incremental Streams [#9](https://github.com/singer-io/tap-ordway/pull/9)
  * Change when Full Table Streams send an `ACTIVATE_VERSION` message [#9](https://github.com/singer-io/tap-ordway/pull/9)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch and bump the version
