### PR TITLE
Changed dtype of discount_value to float as the API returns

### DIFF
--- a/tap_ordway/schemas/coupons.json
+++ b/tap_ordway/schemas/coupons.json
@@ -36,7 +36,7 @@
         },
         "discount_value": {
             "type": [
-                "integer"
+                "float"
             ]
         },
         "duration_period": {


### PR DESCRIPTION
# Description of change
Changed dtype of discount_value to float as the API returns
